### PR TITLE
[TASK] Enrich guide to create seeds & migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,39 @@ typo3cms phinx:seed:run
 
 Notice that these wrapper commands are executed by TYPO3, thus the full API like `DataHandler` can be used in migrations.
 
+## Migrations
+
 The following paths are used for migrations:
 
 * `typo3conf/ext/*/Migrations/Phinx`
 * `typo3conf/ext/*/Classes/Migrations/Phinx`
 
+Examples to create a migration in a TYPO3 project:
+
+* `typo3cms phinx:create --path packages/provider/Classes/Migrations/Phinx MyMigration`
+
+**Note**
+
+If **one** `Migrations` directory exists already, you can omit `--path`.
+However, should multiple exist, you will receive a prompt and have to select
+the desired location.
+
+## Seeds
+
 The following paths are used for seeds:
 
 * `typo3conf/ext/*/Migrations/Phinx/Seeds`
 * `typo3conf/ext/*/Classes/Migrations/Phinx/Seeds`
+
+Examples to create a seed in a TYPO3 project:
+
+* `typo3cms phinx:seed:create --path packages/provider/Classes/Migrations/Phinx/Seed MySeeder`
+
+**Note**
+
+If **one** `Migrations/Seed` directory exists already, you can omit `--path`.
+However, should multiple exist, you will receive a prompt and have to select
+the desired location.
 
 ## Testing
 


### PR DESCRIPTION
While running `ddev typo3cms phinx:seed:create MySeeder` locally I ran into following `Exception`:

```
using migration paths 
 - /var/www/html/packages/typo3-cms-extension/provider/Classes/Migrations/Phinx
using seed paths 

                                                                                                                                                                                               
  [ Exception ]                                                                                                                                                                                
  You probably used curly braces to define seed path in your Phinx configuration file, but no directories have been matched using this pattern. You need to create a seed directory manually.  
                                                                                                                                                                                               

phinx:seed:create [-c|--configuration CONFIGURATION] [-p|--parser PARSER] [--path PATH] [-t|--template TEMPLATE] [--] <name>
```

By providing a `--path` I was able to resolve my issue.