### PR TITLE
Keep migrations table on DB schema update

### DIFF
--- a/Classes/Configuration/PhinxConfiguration.php
+++ b/Classes/Configuration/PhinxConfiguration.php
@@ -7,6 +7,8 @@ use TYPO3\CMS\Core\Core\Environment;
 
 final class PhinxConfiguration
 {
+    public const MIGRATION_TABLE_NAME = 'tx_phinx_log';
+
     public function toArray(): array
     {
         $extensionsPath = Environment::getExtensionsPath();
@@ -24,7 +26,7 @@ final class PhinxConfiguration
                 ),
             ],
             'environments' => [
-                'default_migration_table' => 'tx_phinx_log',
+                'default_migration_table' => self::MIGRATION_TABLE_NAME,
                 'default_environment' => 'typo3',
                 'typo3' => [
                     'adapter' => 'mysql',

--- a/Classes/EventListeners/AlterTableDefinitionStatementsEventListener.php
+++ b/Classes/EventListeners/AlterTableDefinitionStatementsEventListener.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pagemachine\Phinx\EventListeners;
+
+use Doctrine\DBAL\Schema\Table;
+use Pagemachine\Phinx\Configuration\PhinxConfiguration;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\Event\AlterTableDefinitionStatementsEvent;
+
+final class AlterTableDefinitionStatementsEventListener
+{
+    private Connection $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function addPhinxMigrationTableSchema(AlterTableDefinitionStatementsEvent $event): void
+    {
+        $schemaManager = $this->connection->getSchemaManager();
+
+        if (!$schemaManager->tablesExist(PhinxConfiguration::MIGRATION_TABLE_NAME)) {
+            return;
+        }
+
+        $table = $schemaManager->listTableDetails(PhinxConfiguration::MIGRATION_TABLE_NAME);
+        $schemaTableSQL = $this->buildSchemaTableSQL($this->removeColumnCollations($table));
+
+        $event->addSqlData($schemaTableSQL);
+    }
+
+    /**
+     * Remove COLLATE option from columns which are not supported by TYPO3
+     */
+    private function removeColumnCollations(Table $table): Table
+    {
+        $table->getColumn('migration_name')
+            ->setPlatformOptions([]);
+
+        return $table;
+    }
+
+    private function buildSchemaTableSQL(Table $table): string
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        return sprintf('%s;', $platform->getCreateTableSQL($table)[0]);
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -37,3 +37,20 @@ services:
       - name: console.command
         command: phinx:seed:run
         schedulable: false
+
+  connection.default:
+    class: TYPO3\CMS\Core\Database\Connection
+    factory:
+      - '@TYPO3\CMS\Core\Database\ConnectionPool'
+      - getConnectionByName
+    arguments:
+      - !php/const TYPO3\CMS\Core\Database\ConnectionPool::DEFAULT_CONNECTION_NAME
+
+  Pagemachine\Phinx\EventListeners\AlterTableDefinitionStatementsEventListener:
+    arguments:
+      $connection: '@connection.default'
+    tags:
+      - name: event.listener
+        identifier: phinx-migrations
+        method: addPhinxMigrationTableSchema
+        event: TYPO3\CMS\Core\Database\Event\AlterTableDefinitionStatementsEvent


### PR DESCRIPTION
We now fetch and add the Phinx migrations DB table schema. This prevents
TYPO3 from trying to prefix and drop this table. If the table does not
yet exist, we can safely skip this.

Fixes #20