### PR TITLE
[FEATURE] Allow other adapters for Phinx configuration

### DIFF
--- a/Classes/Configuration/PhinxConfiguration.php
+++ b/Classes/Configuration/PhinxConfiguration.php
@@ -4,6 +4,9 @@ declare(strict_types = 1);
 namespace Pagemachine\Phinx\Configuration;
 
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class PhinxConfiguration
 {
@@ -12,7 +15,8 @@ final class PhinxConfiguration
     public function toArray(): array
     {
         $extensionsPath = Environment::getExtensionsPath();
-        $connectionParameters = $this->getConnectionParameters();
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable(self::MIGRATION_TABLE_NAME);
 
         return [
             'paths' => [
@@ -28,22 +32,49 @@ final class PhinxConfiguration
             'environments' => [
                 'default_migration_table' => self::MIGRATION_TABLE_NAME,
                 'default_environment' => 'typo3',
-                'typo3' => [
-                    'adapter' => 'mysql',
-                    'host' => $connectionParameters['host'],
-                    'port' => $connectionParameters['port'],
-                    'user' => $connectionParameters['user'],
-                    'pass' => $connectionParameters['password'],
-                    'name' => $connectionParameters['dbname'],
-                    'unix_socket' => $connectionParameters['unix_socket'] ?? null,
-                    'charset' => $connectionParameters['charset'],
-                ],
+                'typo3' => $this->getEnvironment($connection),
             ],
         ];
     }
 
-    private function getConnectionParameters(): array
+    protected function getEnvironment(Connection $connection): array
     {
-        return $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'];
+        switch ($connection->getDatabasePlatform()->getName()) {
+            case 'sqlite':
+                $pathInfo = pathinfo($connection->getDatabase());
+                $name = $pathInfo['dirname'] . '/' . $pathInfo['filename'];
+                $suffix = '.' . $pathInfo['extension'];
+
+                return [
+                    'adapter' => 'sqlite',
+                    'name' => $name,
+                    'suffix' => $suffix,
+                ];
+            case 'mssql':
+                $adapter = 'sqlsrv';
+                break;
+
+            case 'postgresql':
+                $adapter = 'pgsql';
+                break;
+
+            case 'mysql':
+                $adapter = 'mysql';
+                break;
+
+            default:
+                return [];
+        }
+
+        return [
+            'adapter' => $adapter,
+            'host' => $connection->getParams()['host'] ?? null,
+            'port' => $connection->getParams()['port'] ?? null,
+            'user' => $connection->getParams()['user'] ?? null,
+            'pass' => $connection->getParams()['password'] ?? null,
+            'name' => $connection->getDatabase(),
+            'unix_socket' => $connection->getParams()['unix_socket'] ?? null,
+            'charset' => $connection->getParams()['charset'] ?? null,
+        ];
     }
 }


### PR DESCRIPTION
See: https://book.cakephp.org/phinx/0/en/configuration.html#supported-adapters

My instance crashes as i use sqlite. This PR checks per connection configured configuration and returns the environment array for phinx.