### PR TITLE
Allow robmorgan/phinx 0.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "robmorgan/phinx": "^0.11 || ^0.12 || ^0.13 || ^0.14 || ^2.0",
+        "robmorgan/phinx": "~0.11.0 || ^2.0",
         "typo3/cms-core": "^10.4 || ^11.5 || ^12.4"
     },
     "require-dev": {


### PR DESCRIPTION
Technically any 0.x release can contain breaking changes, still simplifying this reduces the work for new releases. Also there is a version 2.0 by now so the risk of actual breaking changes in 0.x is probably low.