### PR TITLE
Actually allow robmorgan/phinx 0.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "robmorgan/phinx": "~0.11.0 || ^2.0",
+        "robmorgan/phinx": ">= 0.11.0 < 1.0 || ^2.0",
         "typo3/cms-core": "^10.4 || ^11.5 || ^12.4"
     },
     "require-dev": {


### PR DESCRIPTION
The previous attempt actually only allowed 0.11.x. The .0 suffix was added since "composer normalize" would have otherwise changed "~0.11" to "^0.11".

Follows https://github.com/pagemachine/typo3-phinx/pull/46