### PR TITLE
Revert support for robmorgan/phinx 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "robmorgan/phinx": ">= 0.11.0 < 1.0 || ^2.0",
+        "robmorgan/phinx": ">= 0.11.0 < 1.0",
         "typo3/cms-core": "^10.4 || ^11.5 || ^12.4"
     },
     "require-dev": {


### PR DESCRIPTION
Evidently these where released accidentally, so we cannot safely promote support for them anymore. Support may be restored in case of proper releases.

See https://github.com/cakephp/phinx/issues/2221