### PR TITLE
Drop support for PHP 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,6 @@ jobs:
         typo3:
           - ^11.5
           - ^12.4
-        include:
-          - php: '8.0'
-            typo3: ^11.5
 
     steps:
       - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "doctrine/dbal": "^2.0 || ^3.0",
         "robmorgan/phinx": ">= 0.11.0 < 1.0",
         "symfony/console": "^5.4 || ^6.4",


### PR DESCRIPTION
This is EOL since November 2023.

See https://www.php.net/eol.php