### PR TITLE
Drop duplicate Rector TYPO3 set list

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
-use Ssch\TYPO3Rector\Set\Typo3SetList;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -16,7 +15,6 @@ return RectorConfig::configure()
         php81: true,
     )
     ->withSets([
-        Typo3SetList::TYPO3_12,
         Typo3LevelSetList::UP_TO_TYPO3_13,
     ])
 ;


### PR DESCRIPTION
The "up to v13" level set list already covers this.