### PR TITLE
Drop obsolete extensions path support

### DIFF
--- a/Classes/Configuration/PhinxConfiguration.php
+++ b/Classes/Configuration/PhinxConfiguration.php
@@ -15,7 +15,22 @@ final class PhinxConfiguration
         $connectionParameters = $this->getConnectionParameters();
 
         return [
-            'paths' => $this->getPaths(),
+            'paths' => [
+                'migrations' => [
+                    sprintf('%s/migrations/phinx', Environment::getProjectPath()),
+                    sprintf(
+                        '%s/*/*/{Migrations,Classes/Migrations}/Phinx',
+                        $this->getVendorPath(),
+                    ),
+                ],
+                'seeds' => [
+                    sprintf('%s/migrations/phinx/seeds', Environment::getProjectPath()),
+                    sprintf(
+                        '%s/*/*/{Migrations,Classes/Migrations}/Phinx/Seeds',
+                        $this->getVendorPath(),
+                    ),
+                ],
+            ],
             'environments' => [
                 'default_migration_table' => self::MIGRATION_TABLE_NAME,
                 'default_environment' => 'typo3',
@@ -31,46 +46,6 @@ final class PhinxConfiguration
                 ],
             ],
         ];
-    }
-
-    private function getPaths(): array
-    {
-        if ($this->isLocatedInExtensionsPath()) {
-            // <web-dir>/typo3conf/ext/*
-            return [
-                'migrations' => sprintf(
-                    '%s/*/{Migrations,Classes/Migrations}/Phinx',
-                    Environment::getExtensionsPath(),
-                ),
-                'seeds' => sprintf(
-                    '%s/*/{Migrations,Classes/Migrations}/Phinx/Seeds',
-                    Environment::getExtensionsPath(),
-                ),
-            ];
-        }
-
-        // <vendor-dir>/*/*
-        return [
-            'migrations' => [
-                sprintf('%s/migrations/phinx', Environment::getProjectPath()),
-                sprintf(
-                    '%s/*/*/{Migrations,Classes/Migrations}/Phinx',
-                    $this->getVendorPath(),
-                ),
-            ],
-            'seeds' => [
-                sprintf('%s/migrations/phinx/seeds', Environment::getProjectPath()),
-                sprintf(
-                    '%s/*/*/{Migrations,Classes/Migrations}/Phinx/Seeds',
-                    $this->getVendorPath(),
-                ),
-            ],
-        ];
-    }
-
-    private function isLocatedInExtensionsPath(): bool
-    {
-        return dirname(__DIR__, 3) === Environment::getExtensionsPath();
     }
 
     private function getVendorPath(): string

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Notice that these wrapper commands are executed by TYPO3, thus the full API like
 
 The following paths are used for migrations:
 
-* `migrations/phinx` (Composer Mode)
+* `migrations/phinx`
 * `vendor/*/*/Migrations/Phinx`
 * `vendor/*/*/Classes/Migrations/Phinx`
 
@@ -48,7 +48,7 @@ the desired location.
 
 The following paths are used for seeds:
 
-* `migrations/phinx/seeds` (Composer Mode)
+* `migrations/phinx/seeds`
 * `vendor/*/*/Migrations/Phinx/Seeds`
 * `vendor/*/*/Classes/Migrations/Phinx/Seeds`
 


### PR DESCRIPTION
This did exist for TYPO3v11 which did not necessarily have all TYPO3 extnesions in the vendor directory. With TYPO3v12 and newer this is mandatory.