### PR TITLE
Properly pass DSN-only DB connection to Phinx

### DIFF
--- a/Classes/Configuration/PhinxConfiguration.php
+++ b/Classes/Configuration/PhinxConfiguration.php
@@ -34,17 +34,17 @@ final class PhinxConfiguration
             'environments' => [
                 'default_migration_table' => self::MIGRATION_TABLE_NAME,
                 'default_environment' => 'typo3',
-                'typo3' => [
+                'typo3' => array_filter([
                     'adapter' => 'mysql',
-                    'host' => $connectionParameters['host'] ?? null,
-                    'port' => $connectionParameters['port'] ?? null,
-                    'user' => $connectionParameters['user'] ?? null,
-                    'pass' => $connectionParameters['password'] ?? null,
-                    'name' => $connectionParameters['dbname'] ?? null,
-                    'unix_socket' => $connectionParameters['unix_socket'] ?? null,
-                    'charset' => $connectionParameters['charset'] ?? null,
-                    'dsn' => $connectionParameters['url'] ?? null,
-                ],
+                    'host' => $connectionParameters['host'] ?? null ?: null,
+                    'port' => $connectionParameters['port'] ?? null ?: null,
+                    'user' => $connectionParameters['user'] ?? null ?: null,
+                    'pass' => $connectionParameters['password'] ?? null ?: null,
+                    'name' => $connectionParameters['dbname'] ?? null ?: null,
+                    'unix_socket' => $connectionParameters['unix_socket'] ?? null ?: null,
+                    'charset' => $connectionParameters['charset'] ?? null ?: null,
+                    'dsn' => $connectionParameters['url'] ?? null ?: null,
+                ]),
             ],
         ];
     }


### PR DESCRIPTION
When "dsn" is used, all other options should be omitted. As soon as they are set but "null", they will remain "null" in the end since Phinx internally uses the "+" array operator.

We now normalize all options and filter out empty ones before passing them to Phinx.

See https://github.com/cakephp/phinx/blob/0.16.12/src/Phinx/Config/Config.php#L488
And https://stitcher.io/blog/what-is-array-plus-in-php